### PR TITLE
Add API route for connecting test

### DIFF
--- a/src/api/lib/infrastructure/persistent/mongo/connection.ts
+++ b/src/api/lib/infrastructure/persistent/mongo/connection.ts
@@ -1,7 +1,7 @@
 import { ENV_KEY, getEnvValue } from "@/utils/geEnv";
 import mongoose from "mongoose";
 
-const DB_URL = getEnvValue(ENV_KEY.MONGODB_URL);
+const DB_URL = getEnvValue(ENV_KEY.MONGODB_URI);
 
 if (!DB_URL) {
   throw new Error(

--- a/src/api/utils/initialize.ts
+++ b/src/api/utils/initialize.ts
@@ -1,5 +1,5 @@
-import { MongoDBConnection } from "@/api/lib/infrastructure/persistent/mongo/connection";
+import dbConnect from "@/api/lib/infrastructure/persistent/mongo/connection";
 
 export const initializeServer = async () => {
-  await MongoDBConnection.init();
+  await dbConnect();
 };

--- a/src/api/utils/initialize.ts
+++ b/src/api/utils/initialize.ts
@@ -1,5 +1,1 @@
-import dbConnect from "@/api/lib/infrastructure/persistent/mongo/connection";
-
-export const initializeServer = async () => {
-  await dbConnect();
-};
+export const initializeServer = async () => {};

--- a/src/app/api/connect-test/route.ts
+++ b/src/app/api/connect-test/route.ts
@@ -1,0 +1,13 @@
+import { GoogleAuth, UserAuth } from "@/api/lib/domain";
+import { GoogleAuthId } from "@/api/lib/domain/user/auth/GoogleAuthId";
+import { userService } from "@/api/service";
+import { generateId } from "@/api/utils/generateUlid";
+
+export async function POST() {
+  console.log("POST /api/connect-test");
+  const auth = new UserAuth({
+    google: new GoogleAuth(new GoogleAuthId(generateId())),
+  });
+  await userService.create(auth);
+  return new Response("OK", { status: 200 });
+}

--- a/src/app/api/connect-test/route.ts
+++ b/src/app/api/connect-test/route.ts
@@ -1,9 +1,11 @@
 import { GoogleAuth, UserAuth } from "@/api/lib/domain";
 import { GoogleAuthId } from "@/api/lib/domain/user/auth/GoogleAuthId";
+import dbConnect from "@/api/lib/infrastructure/persistent/mongo/connection";
 import { userService } from "@/api/service";
 import { generateId } from "@/api/utils/generateUlid";
 
 export async function POST() {
+  await dbConnect();
   console.log("POST /api/connect-test");
   const auth = new UserAuth({
     google: new GoogleAuth(new GoogleAuthId(generateId())),

--- a/src/component/auth/SignIn.tsx
+++ b/src/component/auth/SignIn.tsx
@@ -19,6 +19,18 @@ export default function Component() {
     <>
       Not signed in <br />
       <button onClick={() => signIn("google")}>Sign in with Google</button>
+      <button
+        onClick={async () => {
+          await fetch("/api/connect-test", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
+        }}
+      >
+        test
+      </button>
     </>
   );
 }

--- a/src/utils/geEnv.ts
+++ b/src/utils/geEnv.ts
@@ -3,6 +3,7 @@ export const enum ENV_KEY {
   NEXTAUTH_SECRET = "NEXTAUTH_SECRET",
   GOOGLE_CLIENT_ID = "GOOGLE_CLIENT_ID",
   GOOGLE_CLIENT_SECRET = "GOOGLE_CLIENT_SECRET",
+  MONGODB_URI = "MONGODB_URI",
 }
 
 export const getEnvValue = (key: ENV_KEY): string => {

--- a/type/override/global.d.ts
+++ b/type/override/global.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  var mongoose:
+    | {
+        conn: mongoose.Connection | null;
+        promise: Promise<mongoose.Connection> | null;
+      }
+    | undefined;
+}
+
+export {};


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a new API route `/api/connect-test` for creating UserAuth with GoogleAuth and saving it using userService. This feature is accessible via a new button in the sign-in component.
- Refactor: Optimized MongoDB connection setup for development, implementing a cached connection to prevent multiple connections during hot reloads. The connection is now established and maintained through the `dbConnect` function.
- Chore: Updated global declarations and environment variables to support the above changes. Added a global declaration for `mongoose` variable and a new enum value `MONGODB_URI` to the `ENV_KEY` enum.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->